### PR TITLE
Copy LICENSE file to docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ COPY --chown=appuser:appgroup src /app
 COPY --chown=appuser:appgroup README.md /app
 COPY --chown=appuser:appgroup pyproject.toml /app
 COPY --chown=appuser:appgroup configs/config.yaml /app
+COPY --chown=appuser:appgroup LICENSE /app
 
 # Switch to the non-root user
 USER appuser


### PR DESCRIPTION
Closes #51

At the moment building the docker image fails because flit tries to find the LICENSE file which isn't copied into the container. Add it to make the docker build step work correctly.